### PR TITLE
[DataCollator] Warn on identical `eos_token_id` and `pad_token_id` in multi-turn training

### DIFF
--- a/src/transformers/data/data_collator.py
+++ b/src/transformers/data/data_collator.py
@@ -649,6 +649,14 @@ class DataCollatorForLanguageModeling(DataCollatorMixin):
 
             self.tf_mask_tokens = tf.function(self.tf_mask_tokens, jit_compile=True)
 
+        if not self.mlm and self.tokenizer.pad_token_id == self.tokenizer.eos_token_id:
+            warnings.warn(
+                "The pad_token_id and eos_token_id values of this tokenizer are identical. "
+                "If you are planning for multi-turn training, "
+                "it can result in the model continuously generating questions and answers without interruption. "
+                "To avoid this, set the pad_token_id to a different value."
+            )
+
     @staticmethod
     def tf_bernoulli(shape, probability):
         import tensorflow as tf


### PR DESCRIPTION
# What does this PR do?
Display a warning message if the `pad_token_id` and `eos_token_id` values are the same in order to prevent unintended behavior during multi-turn training.

for example, at torch_call() at [data_collator.py](https://github.com/huggingface/transformers/blob/7ee995fd9c692761c4601ddbffa2ac2ec9f27b0b/src/transformers/data/data_collator.py#L740C10-L740C10), it convert pad_token_id to ignore_id(-100).

```python
if self.mlm:
    batch["input_ids"], batch["labels"] = self.torch_mask_tokens(
        batch["input_ids"], special_tokens_mask=special_tokens_mask
    )
else:
    labels = batch["input_ids"].clone()
    if self.tokenizer.pad_token_id is not None:
        labels[labels == self.tokenizer.pad_token_id] = -100
    batch["labels"] = labels
```

If the multi-turn data is as shown below, `eos_token_id` and `pad_token_id` are identical, the `eos_token` would not be trained. This results in the model continuously generating user and assistant turns without creating eos token.
```
<s>### User: user message 1\n### Assistant: assistant message 1</s>\n### User: user message 2\n### Assistant: assistant message 2</s>
```

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?